### PR TITLE
verifier behaviour change

### DIFF
--- a/mustbe/verifier/index.js
+++ b/mustbe/verifier/index.js
@@ -72,6 +72,11 @@ Verifier.prototype.isAuthorized = function(activity, requestParams, cb){
 
     var validator = validators[activity];
     if (!validator){
+      // global "deny" or "allow" defined but not passed
+      if(denyAllowConfig.denier || denyAllowConfig.allower) {
+        return cb(null, false);
+      }
+
       var noActivityError = new Error("Activity Not Found, " + activity);
       noActivityError.name = "ActivityNotFoundException";
       return cb(noActivityError, false);

--- a/specs/custom-identity/authorization-override-specs.js
+++ b/specs/custom-identity/authorization-override-specs.js
@@ -128,6 +128,49 @@ describe("custom identity authorization overrides", function(){
     });
   });
 
+
+  describe("when an activity is neither explicitly denied nor explicitly allowed, and no individual activity", function(){
+    var async = new AsyncSpec(this);
+
+    var response, user;
+
+    async.beforeEach(function(done){
+      var mustBe = new MustBe();
+
+      mustBe.configure(function(config){
+        config.routeHelpers(function(rh){
+          rh.notAuthorized(helpers.notAuthorized);
+        });
+
+        config.addIdentity(identityType, MyIdentity);
+        
+        config.activities(identityType, function(activities){
+          activities.deny(function(user, activity, cb){
+            cb(null, false);
+          });
+
+          activities.allow(function(user, activity, cb){
+            cb(null, false);
+          });
+        });
+      });
+
+      var routeHelpers = mustBe.routeHelpers();
+      var request = helpers.setupRoute("/", mustBe, function(handler){
+        return routeHelpers.authorizeIdentity(identityType, "do thing", handler);
+      });
+
+      request(function(err, res){
+        response = res;
+        done();
+      });
+    });
+
+    it("should not allow the request", function(){
+      helpers.expectResponseCode(response, 403);
+    });
+  });
+
   describe("when an activity is neither explicitly denied nor explicitly allowed, but is authorized", function(){
     var async = new AsyncSpec(this);
 


### PR DESCRIPTION
If global “deny” or “allow” defined but not passed, and there isn’t any
activity validator followed, just go to notAuthorized.