### PR TITLE
fix small typo in authorize-routes documentation

### DIFF
--- a/docs/authorize-routes.md
+++ b/docs/authorize-routes.md
@@ -88,7 +88,7 @@ function view(req, res, next){
   res.render("/something");
 }
 
-funciton cannotView(req, res, next){
+function cannotView(req, res, next){
   res.render("/cannot-view");
 }
 ```


### PR DESCRIPTION
While reading documentation, noticed small typo in code example in "Custom Failure Handler" section.
